### PR TITLE
Fix for CUDA12.5

### DIFF
--- a/simple_knn.cu
+++ b/simple_knn.cu
@@ -23,6 +23,7 @@
 #define __CUDACC__
 #include <cooperative_groups.h>
 #include <cooperative_groups/reduce.h>
+#include <float.h>
 
 namespace cg = cooperative_groups;
 


### PR DESCRIPTION
This modification is to fix the build error 'FLT_MAX undefined' on CUDA12.5.

I confirmed that this works with 'MonoGS' (on Ubuntu 22.04)